### PR TITLE
Sec 765 increase cert expiration

### DIFF
--- a/bless/aws_lambda/bless_lambda.py
+++ b/bless/aws_lambda/bless_lambda.py
@@ -11,7 +11,8 @@ import boto3
 import os
 import kmsauth
 from bless.config.bless_config import BlessConfig, BLESS_OPTIONS_SECTION, \
-    CERTIFICATE_VALIDITY_WINDOW_SEC_OPTION, ENTROPY_MINIMUM_BITS_OPTION, RANDOM_SEED_BYTES_OPTION, \
+    CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION, CERTIFICATE_VALIDITY_AFTER_SEC_OPTION, \
+    ENTROPY_MINIMUM_BITS_OPTION, RANDOM_SEED_BYTES_OPTION, \
     BLESS_CA_SECTION, CA_PRIVATE_KEY_FILE_OPTION, LOGGING_LEVEL_OPTION, KMSAUTH_SECTION, \
     KMSAUTH_USEKMSAUTH_OPTION, KMSAUTH_SERVICE_ID_OPTION
 
@@ -52,8 +53,10 @@ def lambda_handler(event, context=None, ca_private_key_password=None,
     logger = logging.getLogger()
     logger.setLevel(numeric_level)
 
-    certificate_validity_window_seconds = config.getint(BLESS_OPTIONS_SECTION,
-                                                        CERTIFICATE_VALIDITY_WINDOW_SEC_OPTION)
+    certificate_validity_before_seconds = config.getint(BLESS_OPTIONS_SECTION,
+                                            CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION)
+    certificate_validity_after_seconds = config.getint(BLESS_OPTIONS_SECTION,
+                                            CERTIFICATE_VALIDITY_AFTER_SEC_OPTION)
     entropy_minimum_bits = config.getint(BLESS_OPTIONS_SECTION, ENTROPY_MINIMUM_BITS_OPTION)
     random_seed_bytes = config.getint(BLESS_OPTIONS_SECTION, RANDOM_SEED_BYTES_OPTION)
     ca_private_key_file = config.get(BLESS_CA_SECTION, CA_PRIVATE_KEY_FILE_OPTION)
@@ -92,8 +95,8 @@ def lambda_handler(event, context=None, ca_private_key_password=None,
 
     # cert values determined only by lambda and its configs
     current_time = int(time.time())
-    valid_before = current_time + certificate_validity_window_seconds
-    valid_after = current_time - certificate_validity_window_seconds
+    valid_before = current_time + certificate_validity_after_seconds
+    valid_after = current_time - certificate_validity_before_seconds
 
     # Authenticate the user with KMS, if key is setup
     if config.get(KMSAUTH_SECTION, KMSAUTH_USEKMSAUTH_OPTION):

--- a/bless/config/bless_config.py
+++ b/bless/config/bless_config.py
@@ -7,7 +7,7 @@ import ConfigParser
 
 BLESS_OPTIONS_SECTION = 'Bless Options'
 CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION = 'certificate_validity_before_seconds'
-CERTIFICATE_VALIDITY_AFTER_SEC_OPTION = 'certificate_validity_before_seconds'
+CERTIFICATE_VALIDITY_AFTER_SEC_OPTION = 'certificate_validity_after_seconds'
 CERTIFICATE_VALIDITY_SEC_DEFAULT = 60 * 2
 
 ENTROPY_MINIMUM_BITS_OPTION = 'entropy_minimum_bits'

--- a/bless/config/bless_config.py
+++ b/bless/config/bless_config.py
@@ -6,7 +6,8 @@
 import ConfigParser
 
 BLESS_OPTIONS_SECTION = 'Bless Options'
-CERTIFICATE_VALIDITY_WINDOW_SEC_OPTION = 'certificate_validity_seconds'
+CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION = 'certificate_validity_before_seconds'
+CERTIFICATE_VALIDITY_AFTER_SEC_OPTION = 'certificate_validity_before_seconds'
 CERTIFICATE_VALIDITY_SEC_DEFAULT = 60 * 2
 
 ENTROPY_MINIMUM_BITS_OPTION = 'entropy_minimum_bits'
@@ -48,7 +49,8 @@ class BlessConfig(ConfigParser.RawConfigParser):
         :param config_file: Path to the connfig file.
         """
         self.aws_region = aws_region
-        defaults = {CERTIFICATE_VALIDITY_WINDOW_SEC_OPTION: CERTIFICATE_VALIDITY_SEC_DEFAULT,
+        defaults = {CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION: CERTIFICATE_VALIDITY_SEC_DEFAULT,
+                    CERTIFICATE_VALIDITY_AFTER_SEC_OPTION: CERTIFICATE_VALIDITY_SEC_DEFAULT,
                     ENTROPY_MINIMUM_BITS_OPTION: ENTROPY_MINIMUM_BITS_DEFAULT,
                     RANDOM_SEED_BYTES_OPTION: RANDOM_SEED_BYTES_DEFAULT,
                     LOGGING_LEVEL_OPTION: LOGGING_LEVEL_DEFAULT,

--- a/bless/config/bless_deploy_example.cfg
+++ b/bless/config/bless_deploy_example.cfg
@@ -1,7 +1,8 @@
 # This section and its options are optional
 [Bless Options]
 # Number of seconds +/- the issued time for the certificate to be valid
-certificate_validity_window_seconds = 120
+certificate_validity_after_seconds = 120
+certificate_validity_before_seconds = 120
 # Minimum number of bits in the system entropy pool before requiring an additional seeding step
 entropy_minimum_bits = 2048
 # Number of bytes of random to fetch from KMS to seed /dev/urandom

--- a/lambda_configs/bless_deploy.cfg
+++ b/lambda_configs/bless_deploy.cfg
@@ -2,7 +2,8 @@
 [Bless Options]
 # Number of seconds +/- the issued time for the certificate to be valid
 certificate_validity_before_seconds = 120
-certificate_validity_after_seconds = 120
+# Make certificate valid for 30 minutes after issue
+certificate_validity_after_seconds = 1800
 # Minimum number of bits in the system entropy pool before requiring an additional seeding step
 entropy_minimum_bits = 2048
 # Number of bytes of random to fetch from KMS to seed /dev/urandom

--- a/lambda_configs/bless_deploy.cfg
+++ b/lambda_configs/bless_deploy.cfg
@@ -1,7 +1,8 @@
 # This section and its options are optional
 [Bless Options]
 # Number of seconds +/- the issued time for the certificate to be valid
-certificate_validity_window_seconds = 120
+certificate_validity_before_seconds = 120
+certificate_validity_after_seconds = 120
 # Minimum number of bits in the system entropy pool before requiring an additional seeding step
 entropy_minimum_bits = 2048
 # Number of bytes of random to fetch from KMS to seed /dev/urandom

--- a/tests/config/full.cfg
+++ b/tests/config/full.cfg
@@ -1,6 +1,7 @@
 [Bless Options]
 # The default values are sane, these are not.
-certificate_validity_seconds = 1
+certificate_validity_after_seconds = 1
+certificate_validity_before_seconds = 1
 entropy_minimum_bits = 2
 random_seed_bytes = 3
 logging_level = DEBUG

--- a/tests/config/test_bless_config.py
+++ b/tests/config/test_bless_config.py
@@ -3,7 +3,8 @@ import os
 import pytest
 
 from bless.config.bless_config import BlessConfig, BLESS_OPTIONS_SECTION, \
-    CERTIFICATE_VALIDITY_WINDOW_SEC_OPTION, ENTROPY_MINIMUM_BITS_OPTION, RANDOM_SEED_BYTES_OPTION, \
+    CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION, CERTIFICATE_VALIDITY_AFTER_SEC_OPTION, \
+    ENTROPY_MINIMUM_BITS_OPTION, RANDOM_SEED_BYTES_OPTION, \
     CERTIFICATE_VALIDITY_SEC_DEFAULT, ENTROPY_MINIMUM_BITS_DEFAULT, RANDOM_SEED_BYTES_DEFAULT, \
     LOGGING_LEVEL_DEFAULT, LOGGING_LEVEL_OPTION
 
@@ -38,7 +39,9 @@ def test_configs(config, region, expected_cert_valid, expected_entropy_min, expe
                  expected_log_level, expected_password):
     config = BlessConfig(region, config_file=config)
     assert expected_cert_valid == config.getint(BLESS_OPTIONS_SECTION,
-                                                CERTIFICATE_VALIDITY_WINDOW_SEC_OPTION)
+                                                CERTIFICATE_VALIDITY_BEFORE_SEC_OPTION)
+    assert expected_cert_valid == config.getint(BLESS_OPTIONS_SECTION,
+                                                CERTIFICATE_VALIDITY_AFTER_SEC_OPTION)
 
     assert expected_entropy_min == config.getint(BLESS_OPTIONS_SECTION,
                                                  ENTROPY_MINIMUM_BITS_OPTION)


### PR DESCRIPTION
Updates lambda to allow independently  setting before/after time configs, and for lyft sets the after config to 30 minutes (1800s).