### PR TITLE
Install from requirements.txt

### DIFF
--- a/lambda_compile.sh
+++ b/lambda_compile.sh
@@ -3,6 +3,6 @@
 yum install -y python37
 python3.7 -m venv /tmp/venv
 /tmp/venv/bin/pip install --upgrade pip setuptools
-/tmp/venv/bin/pip install -e .
+/tmp/venv/bin/pip install -r requirements.txt
 cp -r /tmp/venv/lib/python3.7/site-packages/. ./aws_lambda_libs
 cp -r /tmp/venv/lib64/python3.7/site-packages/. ./aws_lambda_libs


### PR DESCRIPTION
Currently pip install -e . breaks because of a newer version of marshmallow

A different approach is to lock version numbers in setup.py. See #51 
