### PR TITLE
Repair build by installing pinned package versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ lambda_configs/
 .pytest_cache/
 .vscode/settings.json
 *env/
+.venv

--- a/lambda_compile.sh
+++ b/lambda_compile.sh
@@ -3,6 +3,7 @@
 yum install -y python37
 python3.7 -m venv /tmp/venv
 /tmp/venv/bin/pip install --upgrade pip setuptools
+/tmp/venv/bin/pip install -r requirements.txt
 /tmp/venv/bin/pip install -e .
 cp -r /tmp/venv/lib/python3.7/site-packages/. ./aws_lambda_libs
 cp -r /tmp/venv/lib64/python3.7/site-packages/. ./aws_lambda_libs


### PR DESCRIPTION
Hello,

I've noticed the build failing because the script doesn't install pinned dependencies before installing "self" in editable mode

This PR fixes the issue. I can confirm this is working as I used the build script to deploy production lambdas

I'm not sure why the CLA status is still "pending", since I've signed it...