### PR TITLE
Bugfix to allow seeding via KMS

### DIFF
--- a/bless/aws_lambda/bless_lambda_common.py
+++ b/bless/aws_lambda/bless_lambda_common.py
@@ -6,6 +6,7 @@
 import logging
 import os
 
+import base64
 import boto3
 from bless.cache.bless_lambda_cache import BlessLambdaCache
 from bless.config.bless_config import BLESS_OPTIONS_SECTION, LOGGING_LEVEL_OPTION, ENTROPY_MINIMUM_BITS_OPTION, \
@@ -58,8 +59,9 @@ def check_entropy(config, logger):
             response = kms_client.generate_random(
                 NumberOfBytes=random_seed_bytes)
             random_seed = response['Plaintext']
+            random_seed_b64 = base64.b64encode(random_seed).decode('utf-8')
             with open('/dev/urandom', 'w') as urandom:
-                urandom.write(random_seed)
+                urandom.write(random_seed_b64)
 
 
 def setup_lambda_cache(ca_private_key_password, config_file):


### PR DESCRIPTION
bless generates ephemeral certs and relies on noise (randomness) to generate these ephemeral keys. 

For some reason the lambda in `us-east-1`  kernel is reporting that we only have 256 bits available, whereas bless has a minimum of 2046 bits it uses for random generation.  When this occurs, we fallback on using KMS for the random generation, which is currently broken.   `us-west-2` looks to be unaffected.

This PR fixes KMS:
KMS GenerateRandom function returns random bytes.  `urandom.write` expects a string.    To write the string to we b64 encode so we're able to seed `/dev/urandom` to give it extra randomness.