### PR TITLE
[SECFOUND-3765] Update coverage package version from 5.2.1 to 7.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrs==20.1.0
 boto3==1.14.47
 botocore==1.17.47
 cffi==1.17.0
-coverage==5.2.1
+coverage==7.6.1
 cryptography==3.2.1
 docutils==0.15.2
 flake8==3.8.3


### PR DESCRIPTION
### Description:
Updated cffi version to enable python3.8 to python3.10 upgrade. 

### Ticket:
[[SECFOUND-3765] python3.10 upgrade for bless-private](https://jira.lyft.net/browse/SECFOUND-3765)